### PR TITLE
test for length of encoding proposed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,4 +33,6 @@ Encoding: UTF-8
 Language: en
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.0
+RoxygenNote: 7.1.0
+Suggests: 
+    testthat

--- a/R/core.R
+++ b/R/core.R
@@ -288,7 +288,7 @@ czso_get_table <- function(dataset_id, force_redownload = FALSE, resource_num = 
   if(file.exists(dfile) & !force_redownload) {
     usethis::ui_info("File already in {td}, not downloading. Set `force_redownload` to TRUE if needed.")
   } else {
-    utils::download.file(url, dfile, headers = ua_header)
+    curl::curl_download(url, dfile)
   }
 
   # print(dfile)
@@ -311,8 +311,10 @@ czso_get_table <- function(dataset_id, force_redownload = FALSE, resource_num = 
   }
   switch (action,
           read = {
-            guessed_enc <- readr::guess_encoding(dfile)[[1,1]]
-            if(guessed_enc == "windows-1252") guessed_enc <- "windows-1250"
+            guessed_enc <- readr::guess_encoding(dfile)
+            guessed_enc <- ifelse(length(guessed_enc$encoding) == 0 || guessed_enc$encoding == "windows-1252",
+                                  "windows-1250", # a sensible default, considering...
+                                  guessed_enc$encoding[1])
             dt <- suppressWarnings(suppressMessages(readr::read_csv(dfile, col_types = readr::cols(.default = "c",
                                                                                                    rok = "i",
                                                                                                    casref_do = "T",

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(czso)
+
+test_check("czso")

--- a/tests/testthat/test-czso_get_table.R
+++ b/tests/testthat/test-czso_get_table.R
@@ -1,0 +1,6 @@
+context("download works")
+
+# 100013 = Těžba dřeva podle druhů dřevin a typu nahodilé těžby
+
+expect_true(is.data.frame(czso_get_table("100013"))) # je data frame?
+expect_gte(nrow(czso_get_table("100013")), 399) # 399 = počet řádků k 2020-04-23


### PR DESCRIPTION
There seems to be an issue in `czso_get_table()` function on my system (Ubuntu Linux).

In my case `readr::guess_encoding()` - see line no. 314 - returns an empty tibble, and as consequence selecting the first value causes a crash.

I propose a test for length of the `guess_encoding$encoding` vector, and if empty (i.e. subset will crash) use 1250 as a sensible default instead.

Also - and this is a mere suggestion - I have better experience with cross platform reliability of curl::curl_download than utils::download_file (my issues were with binary data, text should be OK, but still...)