### PR TITLE
Explicit calling of usethis::ui_code() proposed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: czso
 Title: Use Open Data from the Czech Statistical Office in R
-Version: 0.3.2
+Version: 0.3.2.9000
 Authors@R: 
     c(person(given = "Petr",
              family = "Bouchal",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# czso (development version)
+
 # czso 0.3.2
 
 * minor README edit for CRAN resubmission 

--- a/R/core.R
+++ b/R/core.R
@@ -332,7 +332,7 @@ czso_get_table <- function(dataset_id, dest_dir = NULL, force_redownload = FALSE
 
   if(stringr::str_detect(dataset_id, "^cis")) {
     usethis::ui_info("The dataset you are fetching seems to be a codelist.")
-    usethis::ui_todo("Use {ui_code(x = stringr::str_glue('czso_get_codelist(\"{dataset_id}\")'))} to load it using a dedicated function.")
+    usethis::ui_todo("Use {usethis::ui_code(x = stringr::str_glue('czso_get_codelist(\"{dataset_id}\")'))} to load it using a dedicated function.")
   }
 
   ptr <- get_czso_resource_pointer(dataset_id, resource_num = resource_num)


### PR DESCRIPTION
Version 0.3.2, ie. the current CRAN version, produces an error in `czso_get_table("cis100")`
```
 Error in ui_code(x = stringr::str_glue("czso_get_codelist(\"{dataset_id}\")")) : 
  could not find function "ui_code" 
```
Explicit calling of `usethis::ui_code()` should take care of that...